### PR TITLE
fix: ez_setup to work with python3

### DIFF
--- a/dist/python/ez_setup.py
+++ b/dist/python/ez_setup.py
@@ -103,7 +103,7 @@ def use_setuptools(
         return do_download()       
     try:
         pkg_resources.require("setuptools>="+version); return
-    except pkg_resources.VersionConflict, e:
+    except pkg_resources.VersionConflict as e:
         if was_imported:
             print >>sys.stderr, (
             "The required version of setuptools (>=%s) is not available, and\n"
@@ -238,8 +238,8 @@ def main(argv, version=DEFAULT_VERSION):
             from setuptools.command.easy_install import main
             main(argv)
         else:
-            print "Setuptools version",version,"or greater has been installed."
-            print '(Run "ez_setup.py -U setuptools" to reinstall or upgrade.)'
+            print("Setuptools version",version,"or greater has been installed.")
+            print('(Run "ez_setup.py -U setuptools" to reinstall or upgrade.)')
 
 def update_md5(filenames):
     """Update our built-in md5 registry"""


### PR DESCRIPTION
This fixes these errors:

```
File "ez_setup.py", line 106
    except pkg_resources.VersionConflict, e:
                                        ^
SyntaxError: invalid syntax
```

After you overcome this error you will get this:

```
File "ez_setup.py", line 241
    print "Setuptools version",version,"or greater has been installed."
                             ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("Setuptools version",version,"or greater has been installed.")?
```